### PR TITLE
Improve birthdate generation

### DIFF
--- a/src/finnish-ssn.js
+++ b/src/finnish-ssn.js
@@ -89,7 +89,11 @@ export default class FinnishSSN {
       }
     }
 
-    year = (today.getFullYear() - age) % 100
+    if (!birthDayPassed(new Date(year, month - 1, dayOfMonth), today)) {
+      year--
+    }
+    year = year % 100
+
     if (year % 100 < 10) {
       year = "0" + year
     }

--- a/src/finnish-ssn.js
+++ b/src/finnish-ssn.js
@@ -35,11 +35,7 @@ export default class FinnishSSN {
           rollingId = ssn.substring(7, 10),
           checksum = ssn.substring(10, 11),
           sex = parseInt(rollingId, 10) % 2 ? this.MALE : this.FEMALE
-    let daysInMonth = daysInMonthMap[month]
-
-    if (month === february && isLeapYear(year)) {
-      daysInMonth++
-    }
+    const daysInMonth = daysInGivenMonth(year, month)
 
     if (!daysInMonthMap.hasOwnProperty(month) || dayOfMonth > daysInMonth) {
       return parseFailedObj
@@ -79,12 +75,12 @@ export default class FinnishSSN {
     }
     let today = new Date(),
         year = today.getFullYear() - age,
-        month = "01",  //  For simplicity
-        dayOfMonth = "01",//  For simplicity
+        month = randomMonth(),
+        dayOfMonth = randomDay(year, month),
         centurySign,
         checksumBase,
         checksum,
-        rollingId = 100 + Math.floor((Math.random() * 799))  //  No need for padding when rollingId >= 100
+        rollingId = 99 + randomNumber(800)  //  No need for padding when rollingId >= 100
 
 
     for (let centuryChar in centuryMap) {
@@ -136,6 +132,24 @@ const
   MAX_AGE = 200,
   SSN_REGEX = /^[0-3][\d][0-1][0-9][0-9]{2}[+\-A][\d]{3}[\dA-Z]$/
 
+
+function randomMonth() {
+  return ("00" + randomNumber(12)).substr(-2, 2)
+}
+
+function randomDay(year, month) {
+  const maxDaysInMonth = daysInGivenMonth(year, month)
+  return ("00" + randomNumber(maxDaysInMonth)).substr(-2, 2)
+}
+
+function daysInGivenMonth(year, month) {
+  const daysInMonth = daysInMonthMap[month]
+  return (month === february && isLeapYear(year)) ? daysInMonth + 1 : daysInMonth
+}
+
+function randomNumber(max) {
+  return Math.floor(Math.random() * max) + 1 // no zero
+}
 
 function isLeapYear(year) {
   return ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)

--- a/test/finnish-ssn_test.js
+++ b/test/finnish-ssn_test.js
@@ -222,14 +222,14 @@ describe("finnishSSN", () => {
       MockDate.set("2/2/2015")
       const age = 3,
           birthYear = "12"
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "A[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}1[12]A[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for 20th century", () => {
       MockDate.set("2/2/2015")
       const age = 20,
           birthYear = "95"
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "-[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}9[45]-[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for 19th century", () => {
@@ -237,21 +237,23 @@ describe("finnishSSN", () => {
 
       const age = 125,
           birthYear = (new Date().getFullYear() - age) % 100
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "\\+[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}[(89)|(90)]\\+[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should createWithAge valid finnishSSN for year 2000", () => {
+      MockDate.set("12/31/2015")
       const age = new Date().getFullYear() - 2000
       expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}00A[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for year 1999", () => {
+      MockDate.set("12/31/2015")
       const age = new Date().getFullYear() - 1999
       expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}99-[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for year 1990", () => {
-      MockDate.set("2/2/2015")
+      MockDate.set("12/31/2015")
       const age = 25
       expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}90-[\\d]{3}[A-Z0-9]"))
     })
@@ -303,6 +305,17 @@ describe("finnishSSN", () => {
         expect(day).to.satisfy(d => (d >= 1 && d <= daysInMonthMax), "Day not between 1 and month's maximum")
       }
     })
-  })
 
+    it("Should create random birth dates with correct (i.e. given) age", () => {
+      const
+        age = 25,
+        ssnsToGenerate = 100
+
+      for (let i = 0; i < ssnsToGenerate; i++) {
+        const ssn = finnishSSN.createWithAge(age)
+        const generatedAge = finnishSSN.parse(ssn).ageInYears
+        expect(generatedAge).to.equal(age)
+      }
+    })
+  })
 })

--- a/test/finnish-ssn_test.js
+++ b/test/finnish-ssn_test.js
@@ -222,14 +222,14 @@ describe("finnishSSN", () => {
       MockDate.set("2/2/2015")
       const age = 3,
           birthYear = "12"
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("0101" + birthYear + "A[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "A[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for 20th century", () => {
       MockDate.set("2/2/2015")
       const age = 20,
           birthYear = "95"
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("0101" + birthYear + "-[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "-[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for 19th century", () => {
@@ -237,23 +237,71 @@ describe("finnishSSN", () => {
 
       const age = 125,
           birthYear = (new Date().getFullYear() - age) % 100
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("0101" + birthYear + "\\+[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}" + birthYear + "\\+[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should createWithAge valid finnishSSN for year 2000", () => {
       const age = new Date().getFullYear() - 2000
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("010100A[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}00A[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for year 1999", () => {
       const age = new Date().getFullYear() - 1999
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("010199-[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}99-[\\d]{3}[A-Z0-9]"))
     })
 
     it("Should create valid finnishSSN for year 1990", () => {
       MockDate.set("2/2/2015")
       const age = 25
-      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("010190-[\\d]{3}[A-Z0-9]"))
+      expect(finnishSSN.createWithAge(age)).to.match(new RegExp("\\d{4}90-[\\d]{3}[A-Z0-9]"))
+    })
+
+    it("Should create random birth dates", () => {
+      const getDayAndMonth = (ssn) => ssn.substr(0, 4)
+
+      const ssnsToCompare = 10,
+        age = 50
+
+      const referenceBirthDate = getDayAndMonth(finnishSSN.createWithAge(age))
+      let i = 0,
+        differenceFound = false
+
+      do {
+        const birthDate = getDayAndMonth(finnishSSN.createWithAge(age))
+        differenceFound = (referenceBirthDate !== birthDate)
+        i++
+      } while (!differenceFound && i < ssnsToCompare)
+
+      expect(differenceFound).to.be.true
+    })
+
+    it("Should create valid birth dates", () => {
+      const isLeapYear = (year) => ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)
+
+      const
+        centuryMap = {"A": 2000, "-": 1900, "+": 1800},
+        daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+        ssnsToGenerate = 1000,
+        age = 40
+
+      for (let i = 0; i < ssnsToGenerate; i++) {
+        const ssn = finnishSSN.createWithAge(age)
+
+        const month = parseInt(ssn.substr(2, 2), 10)
+        expect(month).to.satisfy(m => (m >= 1 && m <= 12), "Month not between 1 and 12")
+
+        const day = parseInt(ssn.substr(0, 2), 10)
+
+        let daysInMonthMax = daysInMonth[month - 1]
+        if (month === 2) {
+          const centuryChar = ssn.substr(6, 1)
+          const year = centuryMap[centuryChar] + parseInt(ssn.substr(4, 2), 10)
+          if (isLeapYear(year)) {
+            daysInMonthMax++
+          }
+        }
+        expect(day).to.satisfy(d => (d >= 1 && d <= daysInMonthMax), "Day not between 1 and month's maximum")
+      }
     })
   })
 


### PR DESCRIPTION
Generate SSNs with random month and day for given age. Also takes into account whether the randomized birth date has already passed and adjusts birth year accordingly, so that the returned SSN really has the given age on the day of generation.