### PR TITLE
Require dates to be formally correct

### DIFF
--- a/src/finnish-ssn.ts
+++ b/src/finnish-ssn.ts
@@ -129,7 +129,7 @@ const checksumTable: string[] = '0123456789ABCDEFHJKLMNPRSTUVWXY'.split('')
 
 const MIN_AGE = 1
 const MAX_AGE = 200
-const SSN_REGEX = /^[0-3][\d][0-1][0-9][0-9]{2}[+\-A][\d]{3}[\dA-Z]$/
+const SSN_REGEX = /^(0[1-9]|[12]\d|3[01])(0[1-9]|1[0-2])([5-9]\d\+|\d\d-|[012]\dA)\d{3}[\dA-Z]$/
 
 function randomMonth(): string {
   return `00${randomNumber(12)}`.substr(-2, 2)


### PR DESCRIPTION
This format of regex will disallow clearly wrong dates, like 00
as date or something else than 01-12 as month etc. Additionally it
will require for the separator character to be correct for the
corresponding century, so + for 1800 etc.

I made the choice to only allow years up to 2029, so this would
require updating every ten years or so.

Fixes #9 