### PR TITLE
Changed NodeJS & Npm version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "Sosiaaliturvatunnus"
   ],
   "engines": {
-    "node": "18.12.0",
-    "npm": "8.8.0"
+    "node": ">=18",
+    "npm": ">=8"
   },
   "scripts": {
     "dist": "tsc && node-minify --compressor babel-minify --input dist/finnish-ssn.js --output dist/finnish-ssn.min.js ",


### PR DESCRIPTION
fix: changed the version constraint for node and npm, to allow equal or higher versions

Fixes #25 