### PR TITLE
SSN generation: Add test iterations to reveal random test failure

### DIFF
--- a/test/finnish-ssn_test.ts
+++ b/test/finnish-ssn_test.ts
@@ -443,10 +443,20 @@ describe('FinnishSSN', () => {
       MockDate.set(`01/01/${currentYear}`)
       const age = currentYear - 2000
 
-      const ssn = FinnishSSN.createWithAge(age)
-      expect(ssn).to.match(new RegExp('\\d{4}99[-|U-Y][\\d]{3}[A-Z0-9]'))
-      const person = FinnishSSN.parse(ssn)
-      expect(person.ageInYears).to.equal(age)
+      const ssnsToGenerate = 10000
+
+      for (let i = 0; i < ssnsToGenerate; i++) {
+        const ssn = FinnishSSN.createWithAge(age)
+        try {
+          expect(ssn).to.match(new RegExp('\\d{4}99[-|U-Y][\\d]{3}[A-Z0-9]'))
+          const person = FinnishSSN.parse(ssn)
+          expect(person.ageInYears).to.equal(age)
+        } catch (e) {
+          const e2 = new Error(`For SSN ${ssn}: ${e}`)
+          e2.stack = e.stack
+          throw e2;
+        }
+      }
     })
 
     it('Should set correct centurySign and age when person is (now.year - 2000) birthday has passed, that is born in 2000', () => {


### PR DESCRIPTION
I accidentally discovered a random failure in a test unrelated to the code I was fixing in another PR. Added a loop of 10000 iterations inside it and it now crashes every time. It fails with two different exceptions:
```
  1) FinnishSSN
       #createWithAge
         Should set correct centurySign and age when person is (now.year - 2000) birthday has not passed, that is born in 1999:
     For SSN 290299U119P: Error: Not valid SSN
  Error: Not valid SSN
      at Function.parse (src/finnish-ssn.ts:39:13)
      at Context.<anonymous> (test/finnish-ssn_test.ts:452:37)
      at processImmediate (node:internal/timers:478:21)
```
```
  1) FinnishSSN
       #createWithAge
         Should set correct centurySign and age when person is (now.year - 2000) birthday has not passed, that is born in 1999:
     For SSN 010100F790X: AssertionError: expected '010100F790X' to match /\d{4}99[-|U-Y][\d]{3}[A-Z0-9]/
  AssertionError: expected '010100F790X' to match /\d{4}99[-|U-Y][\d]{3}[A-Z0-9]/
      at Context.<anonymous> (test/finnish-ssn_test.ts:451:26)
      at processImmediate (node:internal/timers:478:21)
```
I don't have time to fix this myself but in case you do..